### PR TITLE
watch.sh: allow extra parameters for watch

### DIFF
--- a/watch.sh
+++ b/watch.sh
@@ -5,4 +5,4 @@ build_dir=".build"
 ghc --make -Wall -O2 -odir $build_dir -hidir $build_dir site.hs
 ./site build
 ./site clean
-./site watch
+./site watch "$@"


### PR DESCRIPTION
Useful to run as:

    $ ./watch.sh --host=0.0.0.0 --port=12345