### PR TITLE
push_site.sh: always make incremental commits

### DIFF
--- a/push_site.sh
+++ b/push_site.sh
@@ -6,7 +6,7 @@ commit_id=`git log -1 --format=format:"%h: %s (%ai)"`
 
 cd _site
 if [ ! -d .git ]; then
-    git init
+    git init --initial-branch=gh-pages
 
     # reuse local checkout's objects if possible
     alternate_store=$(pwd)/../../aleph_null/.git/objects
@@ -17,9 +17,11 @@ if [ ! -d .git ]; then
         echo "$alternate_store" >> .git/objects/info/alternates
     fi
 
-    git checkout --orphan gh-pages
     git remote add --fetch origin git@github.com:skvadrik/aleph_null.git
+    # Use pristine freshly generated _site state for new commit.
+    # Don't take anything from parent except for the commit ID itself.
+    git reset --soft origin/gh-pages
 fi
 git add .
 git commit -s -m "sync skvadrik.github.io/aleph_null.git:${commit_id}" .
-git push --force -u origin gh-pages
+git push -u origin gh-pages


### PR DESCRIPTION
When `.git` directory is wiped with `./site clean` reconstruct the
history by re-fetching full repository.